### PR TITLE
Docs: Update PHP_CodeSniffer repository link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ Coding Standard
 ---------------
 
 Make sure your code changes comply with the PSR-2 coding standard by
-using [PHP Codesniffer](https://github.com/squizlabs/PHP_CodeSniffer)
+using [PHP Codesniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer)
 from within your folder:
 
     composer phpcs


### PR DESCRIPTION
PHP_CodeSniffer has moved to a new GitHub organization. The `squizlabs/PHP_CodeSniffer` repository is now archived and the project is actively maintained at https://github.com/PHPCSStandards/PHP_CodeSniffer.

See: https://github.com/squizlabs/PHP_CodeSniffer/issues/3932